### PR TITLE
sky.min.css is 404 in cloudflare

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
 
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.1.0/css/reveal.min.css">
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.1.0/css/theme/sky.min.css" id="theme">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.1.0/css/theme/sky.css" id="theme">
 		<link rel="stylesheet" href="css/custom.css">
 
 		<!-- Code syntax highlighting -->


### PR DESCRIPTION
Man Today (Linux Date - Qui 27 Dez 2018 09:08:32 -02), sky.min.css is 404 in Cloudflare.

https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.1.0/css/theme/sky.min.css

![image](https://user-images.githubusercontent.com/19626334/50478270-7817c680-09b7-11e9-90ea-58013d3000e1.png)

Only to workaround, i added the full theme (can when you see this PR,  stop show 404 them can close).

I really like this slides, very helpful to me and my team, thanks for work well and share them.